### PR TITLE
Improve failure modes fro AI data generation

### DIFF
--- a/docs/pages/seed/reference/environment-variables.mdx
+++ b/docs/pages/seed/reference/environment-variables.mdx
@@ -2,9 +2,10 @@
 
 You can use these environment variables to customize the Seed CLI behavior.
 
-| Name                          | Description                                                                   |
-| :---------------------------- | :---------------------------------------------------------------------------- |
-| `OPENAI_API_KEY`              | Use an OpenAI API key to generate examples for text-based entries.            |
-| `GROQ_API_KEY`                | Use a GROQ API key to generate examples for text-based entries.               |
-| `AI_MODEL_NAME`               | Specify the AI model name. Example: `gpt-4-mini,llama-3.1-8b-instant`         |
+| Name                          | Description                                                                            |
+| :---------------------------- | :--------------------------------------------------------------------------------------|
+| `OPENAI_API_KEY`              | Use an OpenAI API key to generate examples for text-based entries.                     |
+| `GROQ_API_KEY`                | Use a GROQ API key to generate examples for text-based entries.                        |
+| `AI_MODEL_NAME`               | Specify the AI model name. Example: `gpt-4-mini,llama-3.1-8b-instant`                  |
+| `AI_CONCURRENCY`              | Specify the number of concurrent requests to make. Default for OpeanAI is 5 and Groq 1 |
 

--- a/packages/seed/src/cli/commands/predict/models.ts
+++ b/packages/seed/src/cli/commands/predict/models.ts
@@ -1,12 +1,8 @@
 import { ChatGroq } from "@langchain/groq";
 import { ChatOpenAI } from "@langchain/openai";
-import { bold, brightGreen } from "#cli/lib/output.js";
 
 export const getCurrentModel = () => {
   const name = process.env["AI_MODEL_NAME"];
-  if (name) {
-    console.log(`${bold("Model Override:")} Using ${brightGreen(name)}`);
-  }
   if (process.env["OPENAI_API_KEY"]) {
     return openAIModel(name);
   }
@@ -32,8 +28,9 @@ const openAIModel = (
 };
 
 const groqModel = (
-  modelName = "llama3-70b-8192",
+  modelName = "llama-3.1-8b-instant",
   apiKey = process.env["GROQ_API_KEY"],
+  concurrency = process.env["AI_CONCURRENCY"] ?? "1", // Currently rate limits are quite low on Groq
 ) => {
   if (!apiKey) {
     throw new Error("GROQ_API_KEY is required to use Groq models");
@@ -41,7 +38,7 @@ const groqModel = (
   return new ChatGroq({
     apiKey,
     model: modelName,
-    maxConcurrency: 10,
+    maxConcurrency: parseInt(concurrency),
   });
 };
 


### PR DESCRIPTION
Added AI_CONCURRENCY env so we can set the concurrency on langchain to help with throttling requests to Groq.
Default to a smaller model on Groq (llama-3.1-8b-instant)
Added retries for requests to LLM (normally fails due to bad JSON format), retries seem to fix it. 
Let generation continue after examples could not be generated for a single column.